### PR TITLE
Updated the removeScrollbarComponent method

### DIFF
--- a/jquery.custom-scrollbar.js
+++ b/jquery.custom-scrollbar.js
@@ -78,9 +78,9 @@
         this.removeScrollbar("vertical");
         this.removeScrollbar("horizontal");
         if (this.overviewAdded)
-          this.$element.unwrap();
+          this.$element.find(".overview").children().unwrap();
         if (this.viewPortAdded)
-          this.$element.unwrap();
+          this.$element.find(".viewport").children().unwrap();
       },
 
       removeScrollbar: function (orientation) {


### PR DESCRIPTION
The old method will clean all elements even if user has additional markup that shouldn't be removed. Updated to target only the .overview and .viewport when removed.

example : 

<div class="container">
<div class="somelengthy content"></div>
<div class="dont remove this"></div>
</div>


old method will remove "the dont remove this" when initialized -> destroy

tested under visual composer plugin for wordpress
