### PR TITLE
not-selectable improvements

### DIFF
--- a/jquery.custom-scrollbar.css
+++ b/jquery.custom-scrollbar.css
@@ -45,13 +45,17 @@
   left: 0;
 }
 
-.not-selectable {
+/** Restrict to Body to prevent conflicts with existing not-selectable classes on web pages. */
+body.not-selectable {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+
+  /* Suppresses all hover, and focus events. */
+  pointer-events: none;
 }
 
 /*Default skin*/
@@ -77,7 +81,8 @@
   -webkit-border-radius: 4px;
 }
 
-.scrollable.default-skin .scroll-bar:hover .thumb {
+.scrollable.default-skin .scroll-bar:hover .thumb,
+.scrollable.default-skin.scrolling .scroll-bar .thumb {
   opacity: 0.6;
 }
 
@@ -96,7 +101,8 @@
   background-color: gray;
 }
 
-.scrollable.gray-skin .scroll-bar:hover .thumb {
+.scrollable.gray-skin .scroll-bar:hover .thumb
+.scrollable.gray-skin.scrolling .scroll-bar .thumb {
   background-color: black;
 }
 

--- a/jquery.custom-scrollbar.css
+++ b/jquery.custom-scrollbar.css
@@ -54,7 +54,10 @@ body.not-selectable {
   -ms-user-select: none;
   user-select: none;
 
-  /* Suppresses all hover, and focus events. */
+  /**
+   * Suppresses all hover, and focus events.
+   * Supports Firefox 3.6+, Chrome 4+, IE 11+, Safari 4+, and Opera 15+
+   */
   pointer-events: none;
 }
 

--- a/jquery.custom-scrollbar.js
+++ b/jquery.custom-scrollbar.js
@@ -361,24 +361,17 @@
       },
 
       startMouseMoveScrolling: function (event) {
+        this.scrollable.$element.addClass('scrolling');
         this.mouseMoveScrolling = true;
         $("body").addClass("not-selectable");
-        this.setUnselectable($("body"), "on");
         this.setScrollEvent(event);
         event.preventDefault();
       },
 
       stopMouseMoveScrolling: function (event) {
+        this.scrollable.$element.removeClass('scrolling');
         this.mouseMoveScrolling = false;
         $("body").removeClass("not-selectable");
-        this.setUnselectable($("body"), null);
-      },
-
-      setUnselectable: function (element, value) {
-        if (element.attr("unselectable") != value) {
-          element.attr("unselectable", value);
-          element.find(':not(input)').attr('unselectable', value);
-        }
       },
 
       mouseMoveScroll: function (event) {


### PR DESCRIPTION
Removed usage of unselectable attributes(slow and lags the complex webpages, and hardly works).

Replaced unselectable attribute with a body.not-selectable class that overrides pointer-events.

Restricted not-selectable(caused bugs on webpages that already use not-selectable on particular elements).

Added a new class when a scrollbar is being scrolled with the mouse.
